### PR TITLE
Ecs drive monitoring in cloudwatch

### DIFF
--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -114,19 +114,19 @@ write_files:
 
         # convert units back to bytes as both docker api and cli only provide freindly units
         if [[ "$1" =~ ([0-9\.]*)B ]] ; then
-          echo "${!BASH_REMATCH[1]}"
+          echo "$${BASH_REMATCH[1]}"
         fi
         if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000 }'
+          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)MB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**2 }'
+          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**2 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)GB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**3 }'
+          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**3 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)TB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**4 }'
+          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**4 }'
         fi
       }
 

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -148,12 +148,12 @@ write_files:
         fi
       }
 
-      asg_name=`aws --region eu-west-1 autoscaling describe-auto-scaling-instances --instance-ids="$AWSINSTANCEID" | jq -r .AutoScalingInstances[0].AutoScalingGroupName`
+      ASG_NAME=`aws --region $AWSREGION autoscaling describe-auto-scaling-instances --instance-ids="$AWSINSTANCEID" | jq -r .AutoScalingInstances[0].AutoScalingGroupName`
 
       data=$(convertUnits `getAvailableMetric Data`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name} --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions AutoScalingGroupName=$${ASG_NAME} --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
       data=$(convertUnits `getAvailableMetric Metadata`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name} --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions AutoScalingGroupName=$${ASG_NAME} --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
 
       total_data=$(convertUnits `getTotalMetric Data`)
       available_data=$(convertUnits `getAvailableMetric Data`)
@@ -162,7 +162,7 @@ write_files:
       total_data=`echo -n $total_data`
 
       utilize=`awk 'BEGIN{ printf "%.0f\n", ('$total_data' - '$available_data')/'$total_data' * 100 }'`
-      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name}" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "AutoScalingGroupName=$${ASG_NAME}" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
 
   - path: "/etc/cron.d/ecs_drive_monitoring"
     permissions: "0644"

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -3,6 +3,9 @@ package_update: true
 packages:
   - aws-cfn-bootstrap
   - unzip
+  - jq
+  - aws-cli
+  - bc
 write_files:
   - path: "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
     permissions: "0644"
@@ -103,17 +106,6 @@ write_files:
     content: |
       #!/bin/bash
 
-      # install aws-cli, bc and jq if required
-      if [ ! -f /usr/bin/aws ]; then
-        yum -qy -d 0 -e 0 install aws-cli
-      fi
-      if [ ! -f /usr/bin/bc ]; then
-        yum -qy -d 0 -e 0 install bc
-      fi
-      if [ ! -f /usr/bin/jq ]; then
-        yum -qy -d 0 -e 0 install jq
-      fi
-
       # Collect region and instanceid from metadata
       AWSREGION=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region`
       AWSINSTANCEID=`curl -ss http://169.254.169.254/latest/meta-data/instance-id`
@@ -125,16 +117,16 @@ write_files:
           echo "$\{BASH_REMATCH[1]\}"
         fi
         if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000 }'
+          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)MB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**2 }'
+          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**2 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)GB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**3 }'
+          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**3 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)TB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**4 }'
+          awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000**4 }'
         fi
       }
 

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -114,7 +114,7 @@ write_files:
 
         # convert units back to bytes as both docker api and cli only provide freindly units
         if [[ "$1" =~ ([0-9\.]*)B ]] ; then
-          echo "$\{BASH_REMATCH[1]\}"
+          echo "${!BASH_REMATCH[1]}"
         fi
         if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
           awk 'BEGIN{ printf "%.0f\n", '${!BASH_REMATCH[1]}' * 1000 }'

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -97,6 +97,96 @@ write_files:
       }
       await_process "/usr/libexec/amazon-ecs-init start"
 
+  - path: "/opt/metricscript.sh"
+    permissions: "0744"
+    owner: "root"
+    content: |
+      #!/bin/bash
+
+      # install aws-cli, bc and jq if required
+      if [ ! -f /usr/bin/aws ]; then
+        yum -qy -d 0 -e 0 install aws-cli
+      fi
+      if [ ! -f /usr/bin/bc ]; then
+        yum -qy -d 0 -e 0 install bc
+      fi
+      if [ ! -f /usr/bin/jq ]; then
+        yum -qy -d 0 -e 0 install jq
+      fi
+
+      # Collect region and instanceid from metadata
+      AWSREGION=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region`
+      AWSINSTANCEID=`curl -ss http://169.254.169.254/latest/meta-data/instance-id`
+
+      function convertUnits {
+
+        # convert units back to bytes as both docker api and cli only provide freindly units
+        if [[ "$1" =~ ([0-9\.]*)B ]] ; then
+          echo "${BASH_REMATCH[1]}"
+        fi
+        if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
+          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000 }'
+        fi
+        if [[ "$1" =~ ([0-9\.]*)MB ]] ; then
+          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**2 }'
+        fi
+        if [[ "$1" =~ ([0-9\.]*)GB ]] ; then
+          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**3 }'
+        fi
+        if [[ "$1" =~ ([0-9\.]*)TB ]] ; then
+          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**4 }'
+        fi
+      }
+
+      function getAvailableMetric {
+        if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then
+          docker info | awk '/'$1' Space Available/ {print tolower($5), $4}'
+        else
+          echo "Metric must be either 'Data' or 'Metadata'"
+          exit 1
+        fi
+      }
+
+      function getTotalMetric {
+        if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then
+          docker info | awk '/'$1' Space Total/ {print tolower($5), $4}'
+        else
+          echo "Metric must be either 'Data' or 'Metadata'"
+          exit 1
+        fi
+      }
+
+      data=$(convertUnits `getAvailableMetric Data`)
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
+      data=$(convertUnits `getAvailableMetric Metadata`)
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
+
+      total_data=$(convertUnits `getTotalMetric Data`)
+      available_data=$(convertUnits `getAvailableMetric Data`)
+
+      available_data=`echo -n $available_data`
+      total_data=`echo -n $total_data`
+
+      utilize=`awk 'BEGIN{ printf "%.0f\n", ('$total_data' - '$available_data')/'$total_data' * 100 }'`
+      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
+
+      [[ -z `aws cloudwatch describe-alarms --region $AWSREGION --alarm-names "ecs-volume-usage" | jq -r '.MetricAlarms' | grep "AlarmArn"` ]] && \
+          aws cloudwatch put-metric-alarm --region $AWSREGION \
+                                          --alarm-name "ecs-volume-usage" \
+                                          --alarm-description "Alarm when docker volume usage reach 80 percent" \
+                                          --metric-name "UtilizationDataStorage" \
+                                          --namespace "System/Linux" \
+                                          --statistic Average \
+                                          --period 60 --threshold 80 --comparison-operator GreaterThanThreshold \
+                                          --dimensions "Name=InstanceId,Value=$AWSINSTANCEID" \
+                                          --evaluation-periods 2 --unit Percent
+
+  - path: "/etc/cron.d/ecs_drive_monitoring"
+    permissions: "0744"
+    owner: "root"
+    content: |
+      *  *  *  *  *   bash /opt/metricscript.sh
+
 runcmd:
   - |
     yum install -y https://amazon-ssm-${region}.s3.amazonaws.com/latest/linux_amd64/amazon-ssm-agent.rpm

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -162,17 +162,6 @@ write_files:
       utilize=`awk 'BEGIN{ printf "%.0f\n", ('$total_data' - '$available_data')/'$total_data' * 100 }'`
       aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
 
-      [[ -z `aws cloudwatch describe-alarms --region $AWSREGION --alarm-names "ecs-volume-usage" | jq -r '.MetricAlarms' | grep "AlarmArn"` ]] && \
-          aws cloudwatch put-metric-alarm --region $AWSREGION \
-                                          --alarm-name "ecs-volume-usage" \
-                                          --alarm-description "Alarm when docker volume usage reach 80 percent" \
-                                          --metric-name "UtilizationDataStorage" \
-                                          --namespace "System/Linux" \
-                                          --statistic Average \
-                                          --period 60 --threshold 80 --comparison-operator GreaterThanThreshold \
-                                          --dimensions "Name=InstanceId,Value=$AWSINSTANCEID" \
-                                          --evaluation-periods 2 --unit Percent
-
   - path: "/etc/cron.d/ecs_drive_monitoring"
     permissions: "0744"
     owner: "root"

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -78,7 +78,7 @@ write_files:
       ECS_ENABLE_CONTAINER_METADATA=true
       ECS_ENABLE_TASK_IAM_ROLE=true
       ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
-      ECS_AVAILABLE_LOGGING_DRIVERS=${logging_drivers}
+      ECS_AVAILABLE_LOGGING_DRIVERS=["awslogs"]
 
   - path: "/usr/local/scripts/cloudformation-signal.sh"
     permissions: "0744"

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -3,9 +3,6 @@ package_update: true
 packages:
   - aws-cfn-bootstrap
   - unzip
-  - jq
-  - aws-cli
-  - bc
 write_files:
   - path: "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
     permissions: "0644"
@@ -81,7 +78,7 @@ write_files:
       ECS_ENABLE_CONTAINER_METADATA=true
       ECS_ENABLE_TASK_IAM_ROLE=true
       ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
-      ECS_AVAILABLE_LOGGING_DRIVERS=["awslogs"]
+      ECS_AVAILABLE_LOGGING_DRIVERS=${logging_drivers}
 
   - path: "/usr/local/scripts/cloudformation-signal.sh"
     permissions: "0744"
@@ -100,75 +97,11 @@ write_files:
       }
       await_process "/usr/libexec/amazon-ecs-init start"
 
-  - path: "/opt/metricscript.sh"
+  - path: "/tmp/custom_script"
     permissions: "0744"
     owner: "root"
     content: |
-      #!/bin/bash
-
-      # Collect region and instanceid from metadata
-      AWSREGION=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region`
-      AWSINSTANCEID=`curl -ss http://169.254.169.254/latest/meta-data/instance-id`
-
-      function convertUnits {
-
-        # convert units back to bytes as both docker api and cli only provide freindly units
-        if [[ "$1" =~ ([0-9\.]*)B ]] ; then
-          echo "$${BASH_REMATCH[1]}"
-        fi
-        if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000 }'
-        fi
-        if [[ "$1" =~ ([0-9\.]*)MB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**2 }'
-        fi
-        if [[ "$1" =~ ([0-9\.]*)GB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**3 }'
-        fi
-        if [[ "$1" =~ ([0-9\.]*)TB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '$${BASH_REMATCH[1]}' * 1000**4 }'
-        fi
-      }
-
-      function getAvailableMetric {
-        if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then
-          docker info | awk '/'$1' Space Available/ {print tolower($5), $4}'
-        else
-          echo "Metric must be either 'Data' or 'Metadata'"
-          exit 1
-        fi
-      }
-
-      function getTotalMetric {
-        if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then
-          docker info | awk '/'$1' Space Total/ {print tolower($5), $4}'
-        else
-          echo "Metric must be either 'Data' or 'Metadata'"
-          exit 1
-        fi
-      }
-
-      ASG_NAME=`aws --region $AWSREGION autoscaling describe-auto-scaling-instances --instance-ids="$AWSINSTANCEID" | jq -r .AutoScalingInstances[0].AutoScalingGroupName`
-
-      data=$(convertUnits `getAvailableMetric Data`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions AutoScalingGroupName=$${ASG_NAME} --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
-      data=$(convertUnits `getAvailableMetric Metadata`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions AutoScalingGroupName=$${ASG_NAME} --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
-
-      total_data=$(convertUnits `getTotalMetric Data`)
-      available_data=$(convertUnits `getAvailableMetric Data`)
-
-      available_data=`echo -n $available_data`
-      total_data=`echo -n $total_data`
-
-      utilize=`awk 'BEGIN{ printf "%.0f\n", ('$total_data' - '$available_data')/'$total_data' * 100 }'`
-      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "AutoScalingGroupName=$${ASG_NAME}" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
-
-  - path: "/etc/cron.d/ecs_drive_monitoring"
-    permissions: "0644"
-    owner: "root"
-    content: |
-      * * * * *    root /opt/metricscript.sh
+      ${custom_script_data}
 
 runcmd:
   - |
@@ -183,3 +116,5 @@ runcmd:
     start ecs
     /usr/local/scripts/cloudformation-signal.sh
     /opt/aws/bin/cfn-signal -e $? --stack ${stack_name} --resource AutoScalingGroup --region ${region}
+  - |
+    /tmp/custom_script.sh

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -163,10 +163,10 @@ write_files:
       aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
 
   - path: "/etc/cron.d/ecs_drive_monitoring"
-    permissions: "0744"
+    permissions: "0644"
     owner: "root"
     content: |
-      *  *  *  *  *   bash /opt/metricscript.sh
+      * * * * *    root /opt/metricscript.sh
 
 runcmd:
   - |

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -122,19 +122,19 @@ write_files:
 
         # convert units back to bytes as both docker api and cli only provide freindly units
         if [[ "$1" =~ ([0-9\.]*)B ]] ; then
-          echo "${BASH_REMATCH[1]}"
+          echo "$\{BASH_REMATCH[1]\}"
         fi
         if [[ "$1" =~ ([0-9\.]*)KB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000 }'
+          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)MB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**2 }'
+          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**2 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)GB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**3 }'
+          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**3 }'
         fi
         if [[ "$1" =~ ([0-9\.]*)TB ]] ; then
-          awk 'BEGIN{ printf "%.0f\n", '${BASH_REMATCH[1]}' * 1000**4 }'
+          awk 'BEGIN{ printf "%.0f\n", '$\{BASH_REMATCH[1]\}' * 1000**4 }'
         fi
       }
 

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -148,10 +148,12 @@ write_files:
         fi
       }
 
+      asg_name=`aws --region eu-west-1 autoscaling describe-auto-scaling-instances --instance-ids="$AWSINSTANCEID" | jq -r .AutoScalingInstances[0].AutoScalingGroupName`
+
       data=$(convertUnits `getAvailableMetric Data`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name} --unit Bytes --metric-name FreeDataStorage --region $AWSREGION
       data=$(convertUnits `getAvailableMetric Metadata`)
-      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $data --namespace "System/Linux" --dimensions InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name} --unit Bytes --metric-name FreeMetadataStorage --region $AWSREGION
 
       total_data=$(convertUnits `getTotalMetric Data`)
       available_data=$(convertUnits `getAvailableMetric Data`)
@@ -160,7 +162,7 @@ write_files:
       total_data=`echo -n $total_data`
 
       utilize=`awk 'BEGIN{ printf "%.0f\n", ('$total_data' - '$available_data')/'$total_data' * 100 }'`
-      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
+      aws cloudwatch put-metric-data --value $utilize --namespace "System/Linux" --dimensions "InstanceId=$AWSINSTANCEID,AutoScalingGroupName=$${asg_name}" --unit Percent --metric-name UtilizationDataStorage --region $AWSREGION
 
   - path: "/etc/cron.d/ecs_drive_monitoring"
     permissions: "0644"

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -97,12 +97,6 @@ write_files:
       }
       await_process "/usr/libexec/amazon-ecs-init start"
 
-  - path: "/tmp/custom_script"
-    permissions: "0744"
-    owner: "root"
-    content: |
-      ${custom_script_data}
-
 runcmd:
   - |
     yum install -y https://amazon-ssm-${region}.s3.amazonaws.com/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -116,5 +110,3 @@ runcmd:
     start ecs
     /usr/local/scripts/cloudformation-signal.sh
     /opt/aws/bin/cfn-signal -e $? --stack ${stack_name} --resource AutoScalingGroup --region ${region}
-  - |
-    /tmp/custom_script.sh

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -52,6 +52,8 @@ data "aws_iam_policy_document" "permissions" {
       "logs:CreateLogGroup",
       "logs:PutLogEvents",
       "ssm:GetParameter",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:PutMetricAlarm"
     ]
   }
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -20,7 +20,6 @@ data "template_file" "main" {
     log_group_name   = "${aws_cloudwatch_log_group.main.name}"
     ecs_cluster_name = "${aws_ecs_cluster.main.name}"
     ecs_log_level    = "${var.ecs_log_level}"
-    logging_drivers  = "[\"${join("\",\"", var.logging_drivers)}\"]"
   }
 }
 
@@ -76,13 +75,13 @@ module "asg" {
   version = "0.2.0"
 
   name_prefix          = "${var.name_prefix}-cluster"
-  user_data            = "${coalesce(var.custom_user_data, data.template_file.main.rendered)}"
+  user_data            = "${coalesce(var.user_data, data.template_file.main.rendered)}"
   vpc_id               = "${var.vpc_id}"
   subnet_ids           = "${var.subnet_ids}"
   await_signal         = "true"
   pause_time           = "PT5M"
   health_check_type    = "EC2"
-  instance_policy      = "${coalesce(var.custom_permissions, data.aws_iam_policy_document.permissions.json)}"
+  instance_policy      = "${data.aws_iam_policy_document.permissions.json}"
   min_size             = "${var.min_size}"
   max_size             = "${var.max_size}"
   instance_type        = "${var.instance_type}"

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -21,7 +21,7 @@ data "template_file" "main" {
     ecs_cluster_name   = "${aws_ecs_cluster.main.name}"
     ecs_log_level      = "${var.ecs_log_level}"
     custom_script_data = "${var.custom_script_data}"
-    logging_drivers    = "${var.logging_drivers}"
+    logging_drivers    = ["${var.logging_drivers}"]
   }
 }
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -115,7 +115,7 @@ resource "random_integer" "alarm_random_postfix" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "UtilizationDataStorageAlarm" {
-  count               = "${var.allow_docker_drive_monitoring == true ? 1 : 0}"
+  count               = "${var.allow_docker_drive_monitoring ? 1 : 0}"
   alarm_name          = "ecs-volume-usage-${random_integer.alarm_random_postfix.result}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "permissions" {
       "logs:CreateLogGroup",
       "logs:PutLogEvents",
       "ssm:GetParameter",
+      "autoscaling:DescribeAutoScalingInstances"
     ]
   }
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -15,11 +15,13 @@ data "template_file" "main" {
   template = "${file("${path.module}/cloud-config.yml")}"
 
   vars {
-    stack_name       = "${var.name_prefix}-cluster-asg"
-    region           = "${data.aws_region.current.name}"
-    log_group_name   = "${aws_cloudwatch_log_group.main.name}"
-    ecs_cluster_name = "${aws_ecs_cluster.main.name}"
-    ecs_log_level    = "${var.ecs_log_level}"
+    stack_name         = "${var.name_prefix}-cluster-asg"
+    region             = "${data.aws_region.current.name}"
+    log_group_name     = "${aws_cloudwatch_log_group.main.name}"
+    ecs_cluster_name   = "${aws_ecs_cluster.main.name}"
+    ecs_log_level      = "${var.ecs_log_level}"
+    custom_script_data = "${var.custom_script_data}"
+    logging_drivers    = "${var.logging_drivers}"
   }
 }
 
@@ -29,31 +31,7 @@ data "aws_iam_policy_document" "permissions" {
     effect    = "Allow"
     resources = ["*"]
 
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecs:CreateCluster",
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
-      "ecs:RegisterContainerInstance",
-      "ecs:StartTelemetrySession",
-      "ecs:Submit*",
-      "logs:CreateLogStream",
-      "cloudwatch:PutMetricData",
-      "ec2:DescribeTags",
-      "logs:DescribeLogStreams",
-      "logs:CreateLogGroup",
-      "logs:PutLogEvents",
-      "ssm:GetParameter",
-      "autoscaling:DescribeAutoScalingInstances"
-    ]
+    actions = "${var.allowed_actions}"
   }
 
   statement {
@@ -108,26 +86,4 @@ resource "aws_security_group_rule" "ingress" {
   from_port                = "32768"
   to_port                  = "65535"
   source_security_group_id = "${element(var.load_balancers, count.index)}"
-}
-
-resource "random_integer" "alarm_random_postfix" {
-  min = 11111
-  max = 99999
-}
-
-resource "aws_cloudwatch_metric_alarm" "UtilizationDataStorageAlarm" {
-  count               = "${var.allow_docker_drive_monitoring ? 1 : 0}"
-  alarm_name          = "ecs-volume-usage-${random_integer.alarm_random_postfix.result}"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "UtilizationDataStorage"
-  namespace           = "System/Linux"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "${var.docker_drive_monitoring_threshold}"
-  alarm_description   = "Alarm when docker volume usage reach ${var.docker_drive_monitoring_threshold} percent"
-
-  dimensions {
-    AutoScalingGroupName = "${module.asg.id}"
-  }
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -21,7 +21,7 @@ data "template_file" "main" {
     ecs_cluster_name   = "${aws_ecs_cluster.main.name}"
     ecs_log_level      = "${var.ecs_log_level}"
     custom_script_data = "${var.custom_script_data}"
-    logging_drivers    = ["${var.logging_drivers}"]
+    logging_drivers    = "[${join(",", var.logging_drivers)}]"
   }
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -4,42 +4,18 @@
 
 variable "logging_drivers" {
   description = "Logging drivers used in ECS instances."
+  type        = "list"
   default     = ["awslogs"]
 }
 
-variable "custom_script_data" {
+variable "custom_user_data" {
   description = "Custom user data script to be started on instance creation."
   default     = ""
 }
 
-variable "allowed_actions" {
-  description = "Allowed actions in AWS policy document."
-
-  default = [
-    "ecr:GetAuthorizationToken",
-    "ecr:BatchCheckLayerAvailability",
-    "ecr:GetDownloadUrlForLayer",
-    "ecr:GetRepositoryPolicy",
-    "ecr:DescribeRepositories",
-    "ecr:ListImages",
-    "ecr:DescribeImages",
-    "ecr:BatchGetImage",
-    "ecs:CreateCluster",
-    "ecs:DeregisterContainerInstance",
-    "ecs:DiscoverPollEndpoint",
-    "ecs:Poll",
-    "ecs:RegisterContainerInstance",
-    "ecs:StartTelemetrySession",
-    "ecs:Submit*",
-    "logs:CreateLogStream",
-    "cloudwatch:PutMetricData",
-    "ec2:DescribeTags",
-    "logs:DescribeLogStreams",
-    "logs:CreateLogGroup",
-    "logs:PutLogEvents",
-    "ssm:GetParameter",
-    "autoscaling:DescribeAutoScalingInstances",
-  ]
+variable "custom_permissions" {
+  description = "Custom JSON permissions list."
+  default     = ""
 }
 
 variable "name_prefix" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -1,6 +1,16 @@
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
+variable "docker_drive_monitoring_threshold" {
+  description = "Threshold for monitoring the ECS docker drive."
+  default     = 80
+}
+
+variable "allow_docker_drive_monitoring" {
+  description = "Flag to create/not the alarm regarding the inner docker volume."
+  default     = false
+}
+
 variable "name_prefix" {
   description = "A prefix used for naming resources."
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -2,19 +2,8 @@
 # Variables
 # ------------------------------------------------------------------------------
 
-variable "logging_drivers" {
-  description = "Logging drivers used in ECS instances."
-  type        = "list"
-  default     = ["awslogs"]
-}
-
-variable "custom_user_data" {
-  description = "Custom user data script to be started on instance creation."
-  default     = ""
-}
-
-variable "custom_permissions" {
-  description = "Custom JSON permissions list."
+variable "user_data" {
+  description = "The user data to provide when launching the instance."
   default     = ""
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -1,14 +1,45 @@
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
-variable "docker_drive_monitoring_threshold" {
-  description = "Threshold for monitoring the ECS docker drive."
-  default     = 80
+
+variable "logging_drivers" {
+  description = "Logging drivers used in ECS instances."
+  default     = ["awslogs"]
 }
 
-variable "allow_docker_drive_monitoring" {
-  description = "Flag to create/not the alarm regarding the inner docker volume."
-  default     = false
+variable "custom_script_data" {
+  description = "Custom user data script to be started on instance creation."
+  default     = ""
+}
+
+variable "allowed_actions" {
+  description = "Allowed actions in AWS policy document."
+
+  default = [
+    "ecr:GetAuthorizationToken",
+    "ecr:BatchCheckLayerAvailability",
+    "ecr:GetDownloadUrlForLayer",
+    "ecr:GetRepositoryPolicy",
+    "ecr:DescribeRepositories",
+    "ecr:ListImages",
+    "ecr:DescribeImages",
+    "ecr:BatchGetImage",
+    "ecs:CreateCluster",
+    "ecs:DeregisterContainerInstance",
+    "ecs:DiscoverPollEndpoint",
+    "ecs:Poll",
+    "ecs:RegisterContainerInstance",
+    "ecs:StartTelemetrySession",
+    "ecs:Submit*",
+    "logs:CreateLogStream",
+    "cloudwatch:PutMetricData",
+    "ec2:DescribeTags",
+    "logs:DescribeLogStreams",
+    "logs:CreateLogGroup",
+    "logs:PutLogEvents",
+    "ssm:GetParameter",
+    "autoscaling:DescribeAutoScalingInstances",
+  ]
 }
 
 variable "name_prefix" {


### PR DESCRIPTION
This is an addition to our ECS cluster to create a script which would keep track of inner ECS docker drive. It creates three metrics and bind it with alert which triggers at 80%. I noticed we use cloudwatch-agent but I haven't found any documentation which would help me create something similar without using external script.