### PR TITLE
Added stop_timeout feature to task definition

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -96,6 +96,7 @@ resource "aws_ecs_task_definition" "main" {
             "awslogs-stream-prefix": "container"
         }
     },
+    "stopTimeout": ${var.stop_timeout},
     "command": ${jsonencode(var.task_container_command)},
     "environment": ${jsonencode(data.null_data_source.environment.*.outputs)}
 }]

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -37,6 +37,12 @@ variable "health_check_grace_period" {
   type        = number
 }
 
+variable "stop_timeout" {
+  default     = 30
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The default is 30 seconds."
+  type        = number
+}
+
 variable "desired_count" {
   description = "The number of instances of the task definition to place and keep running."
   default     = 1


### PR DESCRIPTION
Allow for the possibility that tasks may use more than the default of 30 seconds to stop.

Some programs will loose data if they are not allowed more time to finish off.

This is a change that will force a new task definition resource, specifying the stop time. This will also force a redeploy of the task instances in the service, as the service will also be updated.

It can probably be made non-changing with a json marshaller, like in this one: https://github.com/cloudposse/terraform-aws-ecs-container-definition

Should we do that instead, or is this okay?