### PR TITLE
Fix dynamic port in default example

### DIFF
--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -177,3 +177,8 @@ data "aws_iam_policy_document" "privileges" {
     ]
   }
 }
+
+output "task_url" {
+  description = "Url to the task"
+  value       = "${module.alb.dns_name}/app/"
+}

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -133,7 +133,6 @@ module "application" {
   }
 
   health_check = {
-    port    = 80
     path    = "/"
     matcher = "200"
   }

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -180,5 +180,5 @@ data "aws_iam_policy_document" "privileges" {
 
 output "task_url" {
   description = "Url to the task"
-  value       = "${module.alb.dns_name}/app/"
+  value       = "http://${module.alb.dns_name}/app/"
 }


### PR DESCRIPTION
`health_check.port` was set to `80` but the container used dynamic mapping which caused the example to fail. Since port defaults to dynamic, removing it fixes the problem.