### PR TITLE
ECS cluster module - fixed awscli installation

### DIFF
--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -103,11 +103,12 @@ write_files:
 
 runcmd:
 - |
+  yum install -y unzip
   yum install -y https://s3.dualstack.${region}.amazonaws.com/amazon-ssm-${region}/latest/linux_amd64/amazon-ssm-agent.rpm
-  curl -O https://bootstrap.pypa.io/get-pip.py
-  python get-pip.py --user
   export PATH=~/.local/bin:$PATH
-  pip install awscli --upgrade --user
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip -qq awscliv2.zip
+  ./aws/install -b /usr/bin
   curl -O https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
   rpm -U ./amazon-cloudwatch-agent.rpm
   /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s

--- a/modules/cluster/cloud-config.yml
+++ b/modules/cluster/cloud-config.yml
@@ -109,6 +109,7 @@ runcmd:
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
   unzip -qq awscliv2.zip
   ./aws/install -b /usr/bin
+  rm -rf aws awscliv2.zip
   curl -O https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
   rpm -U ./amazon-cloudwatch-agent.rpm
   /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s


### PR DESCRIPTION
The old way of installation awscli stopped working in Governance Portal stuff. 
